### PR TITLE
Implement QRZ-Lookup Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 /KissXPLog/data/
 /KissXPLog/build_stuff/*/
 **/KissXPLog.log**
+
+#Test
+tests/tmp/**

--- a/KissXPLog/config.py
+++ b/KissXPLog/config.py
@@ -5,6 +5,7 @@ import os
 work_dir = os.path.dirname(os.path.realpath(__file__))
 data_dir = os.path.join(work_dir, "data")
 config_file = os.path.join(data_dir, "config.json")
+plist_path = os.path.join(data_dir, 'dxcc.plist')
 
 
 class UserConfig:

--- a/KissXPLog/qrz_lookup.py
+++ b/KissXPLog/qrz_lookup.py
@@ -2,6 +2,7 @@ import logging
 import os.path
 import plistlib
 import requests
+from KissXPLog import config
 
 
 # Source PLIST File: https://www.country-files.com/cty/cty.plist
@@ -9,29 +10,33 @@ import requests
 def update_plist(plist_path: str):
     url = 'https://www.country-files.com/cty/cty.plist'
     logging.debug(f"Fetch new Plist from {url}....\n")
-    r = requests.get(url, allow_redirects=True)
-    open(plist_path, 'wb').write(r.content)
+    requests.options(allow_redirects=True, url=url)
+    r = requests.get(url)
+    with open(plist_path, 'wb') as pf:
+        pf.write(r.content)
     logging.debug(f"Updated CTY.plist..")
     return None
 
 
 def get_plist():
-    plist_path = "../cty.plist"
-    if not os.path.exists(plist_path):
-        update_plist(plist_path)
+    if not os.path.exists(config.plist_path):
+        update_plist(config.plist_path)
     else:
         logging.debug(f"File exists, no download necessary")
-
-    with open(plist_path, 'rb') as plist_file:
-        data = plistlib.load(plist_file)
-    return data
+    try:
+        with open(config.plist_path, 'rb') as plist_file:
+            plist_data = plistlib.load(plist_file)
+    except FileNotFoundError:
+        plist_data = "File not found"
+        logging.error("File {} not found".format(str(config.plist_path)))
+    return plist_data
 
 
 def get_dxcc_from_callsign(callsign: str):
     dxcc = get_plist()
-    # Alle Keys zu all_regex hinzufügen
+    # Add all keys to all_regex
     all_regex = list(dxcc.keys())
-    # Sortiere von Lang nach kurz
+    # Sort list by callsign-length (descending)
     all_regex.sort(key=len, reverse=True)
 
     for element in all_regex:

--- a/tests/unit/test_qrz_lookup.py
+++ b/tests/unit/test_qrz_lookup.py
@@ -1,0 +1,66 @@
+import os
+import plistlib
+import tempfile
+import unittest
+from unittest.mock import patch, mock_open, Mock
+
+from KissXPLog.qrz_lookup import update_plist, get_plist
+from KissXPLog import config
+
+
+class PlistTestCase(unittest.TestCase):
+
+    @patch('KissXPLog.config.plist_path', "../tmp/test_plist.plist")
+    def test_update_plist(self):
+        with patch('requests.get') as mock_request:
+            url = 'https://www.country-files.com/cty/cty.plist'
+
+            # set a `status_code` attribute on the mock object
+            # with value 200
+            mock_request.return_value.status_code = 200
+            # set fake content
+            mock_request.return_value.content = b'Yep, this PLIST is working'
+
+            try:
+                update_plist(config.plist_path)
+                with open(config.plist_path) as cf:
+                    contents = cf.read()
+            finally:
+                os.remove(config.plist_path)
+            # test if requests.get was called
+            # with the given url or not
+            mock_request.assert_called_once_with(url)
+            self.assertEqual(contents, "Yep, this PLIST is working")
+
+    @patch('KissXPLog.config.plist_path', "../tmp/test_plist.plist")
+    def test_get_plist_file_exists(self):
+        pl = dict(
+            TestCase=dict(
+                Country='Sov Mil Order of Malta',
+                Prefix='1A',
+                ADIF=246,
+                CQZone=15,
+                ITUZone=28,
+                Continent='EU',
+                Latitude=41.9,
+                Longitude=-12.43,
+                GMTOffset=-1.0,
+                ExactCallsign=False, ),
+        )
+        with open(config.plist_path, 'wb') as fp:
+            plistlib.dump(pl, fp)
+        plist = get_plist()
+        self.assertEqual(plist, pl)
+
+        return None
+
+    @patch('KissXPLog.config.plist_path', "../tmp/test_plist.plist")
+    def test_get_plist_file_not_exists(self):
+        try:
+            os.remove(config.plist_path)
+        except FileNotFoundError:
+            print("File does not exist, no deleting necessary, carry on...")
+
+        with patch("KissXPLog.qrz_lookup.update_plist") as update_plist_patch:
+            get_plist()
+        update_plist_patch.assert_called()


### PR DESCRIPTION
Fix unclean file-opens

Replace temp-file with patched config-path in first test.

Replace UNIX-specific patched path to local, platform-independent one

Move plist_path to config.py